### PR TITLE
fix: initialise indent_text at given index when inserting a new row

### DIFF
--- a/lua/table-nvim/md_table.lua
+++ b/lua/table-nvim/md_table.lua
@@ -291,6 +291,7 @@ function MdTable:insert_row_at(index)
   row[col_count] = cell_x
 
   table.insert(self.rows, index, row)
+  table.insert(self.indent_text, index, self.indent_text[index] or self.indent_text[index - 1])
 
   return index
 end


### PR DESCRIPTION
fix for issue: Error adding new row at bottom of table #11

Closes #11