### PR TITLE
Fixed treesitter node range errors.

### DIFF
--- a/lua/table-nvim/init.lua
+++ b/lua/table-nvim/init.lua
@@ -12,6 +12,7 @@ api.nvim_create_autocmd({ 'InsertLeave' }, {
   group = group_id,
   pattern = { '*.md', '*.mdx' },
   callback = function()
+	ts.get_parser(0):parse(false) -- false only parses empty ranges
     local root = utils.get_tbl_root(ts.get_node());
     if not root then return end
 


### PR DESCRIPTION
Not sure if this is an issue that was only impacting me, but I had a situation where if I made back-to-back edits in a cell, it would delete the entire cell contents of the table.

The issue appears to have been the ranges not being updated properly at time of parsing, so the text content extracted during `get_node_text` where blank. The solution that worked for me is to reparse the tree before extracting any nodes.

The `false` parameter claims to only parse nodes with empty ranges, so I believe it should only reparse modified sections of the tree. I have not experienced any performance hits personally.